### PR TITLE
add kfp outputs

### DIFF
--- a/google_cloud_automlops/orchestration/kfp/scaffold.py
+++ b/google_cloud_automlops/orchestration/kfp/scaffold.py
@@ -137,6 +137,7 @@ def get_function_outputs(func: Callable) -> dict:
         metadata['name'] = name, 
         metadata['type'] = type_    
         metadata['description'] = None
+        outputs.append(metadata)
     return update_params(outputs)
 
 

--- a/google_cloud_automlops/orchestration/kfp/scaffold.py
+++ b/google_cloud_automlops/orchestration/kfp/scaffold.py
@@ -109,7 +109,7 @@ def get_packages_to_install_command(func: Optional[Callable] = None,
     return ['sh', '-c', install_python_packages_script, src_code]
 
 
-def get_function_outputs(func: Callable) -> dict:
+def get_function_outputs(func: Callable) -> list:
     """Returns a formatted list of parameters.
 
     Args:
@@ -118,30 +118,30 @@ def get_function_outputs(func: Callable) -> dict:
     Returns:
         list: return value list with types converted to kubeflow spec.
     Raises:
-        Exception: If return type if provided and not a NamedTuple.
+        Exception: If return type is provided and not a NamedTuple.
     """
-            
     annotation = inspect.signature(func).return_annotation
     annotation = maybe_strip_optional_from_annotation(annotation)
 
     # No annotations provided
+    # pylint: disable=protected-access
     if annotation == inspect._empty:
-        return 
-    
+        return None
+
     if not (hasattr(annotation,'__annotations__') and isinstance(annotation.__annotations__, dict)):
         raise TypeError(f'''Return type hint for function "{func.__name__}" must be a NamedTuple.''')
 
     outputs = []
     for name, type_ in annotation.__annotations__.items():
         metadata = {}
-        metadata['name'] = name, 
-        metadata['type'] = type_    
+        metadata['name'] = name
+        metadata['type'] = type_
         metadata['description'] = None
         outputs.append(metadata)
     return update_params(outputs)
 
 
-def get_function_parameters(func: Callable) -> dict:
+def get_function_parameters(func: Callable) -> list:
     """Returns a formatted list of parameters.
 
     Args:

--- a/google_cloud_automlops/orchestration/kfp/scaffold.py
+++ b/google_cloud_automlops/orchestration/kfp/scaffold.py
@@ -64,7 +64,7 @@ def create_component_scaffold(func: Optional[Callable] = None,
     component_spec['name'] = name
     if description:
         component_spec['description'] = description
-    outputs = get_function_outputs(func)
+    outputs = get_function_return_types(func)
     if outputs:
         component_spec['outputs'] = outputs
     component_spec['inputs'] = get_function_parameters(func)
@@ -109,8 +109,8 @@ def get_packages_to_install_command(func: Optional[Callable] = None,
     return ['sh', '-c', install_python_packages_script, src_code]
 
 
-def get_function_outputs(func: Callable) -> list:
-    """Returns a formatted list of parameters.
+def get_function_return_types(func: Callable) -> list:
+    """Returns a formatted list of function return types.
 
     Args:
         func: The python function to create a component from. The function
@@ -121,7 +121,8 @@ def get_function_outputs(func: Callable) -> list:
         Exception: If return type is provided and not a NamedTuple.
     """
     annotation = inspect.signature(func).return_annotation
-    annotation = maybe_strip_optional_from_annotation(annotation)
+    if maybe_strip_optional_from_annotation(annotation) is not annotation:
+        raise TypeError('Return type cannot be Optional.')
 
     # No annotations provided
     # pylint: disable=protected-access

--- a/tests/unit/orchestration/kfp/scaffold_test.py
+++ b/tests/unit/orchestration/kfp/scaffold_test.py
@@ -70,15 +70,15 @@ def full_name() -> NamedTuple('output', [('first', str), ('last', str)]):
     """
     return 'jack', 'smith'
 
-def friends(a: Optional[float]) -> Optional[NamedTuple('output', [('count', int)])]:
+def optional_friend_count(count: Optional[float]) -> Optional[NamedTuple('output', [('count', int)])]:
     """Testing
 
     Args:
-        a (optional[float]): Float n
+        count (optional[float]): count of friends
     """
-    if not a:
+    if not count:
         return None
-    return a
+    return count
 
 def age() -> int:
     """Testing
@@ -297,7 +297,7 @@ def test_get_compile_step(func_name: str):
             does_not_raise()
         ),
         (
-            friends,
+            optional_friend_count,
             None,
             pytest.raises(TypeError)
         ),

--- a/tests/unit/orchestration/kfp/scaffold_test.py
+++ b/tests/unit/orchestration/kfp/scaffold_test.py
@@ -65,26 +65,6 @@ def div(a: float, b: float):
     """
     return a/b
 
-def full_name() -> NamedTuple('output', [('first', str), ('last', str)]):
-    """Testing
-    """
-    return 'jack', 'smith'
-
-def optional_friend_count(count: Optional[float]) -> Optional[NamedTuple('output', [('count', int)])]:
-    """Testing
-
-    Args:
-        count (optional[float]): count of friends
-    """
-    if not count:
-        return None
-    return count
-
-def age() -> int:
-    """Testing
-    """
-    return 65
-
 
 @pytest.mark.parametrize(
     'func, packages_to_install, expectation, has_return_type',
@@ -283,46 +263,56 @@ def test_get_compile_step(func_name: str):
 
 
 @pytest.mark.parametrize(
-    'func, return_types, expectation',
+    'return_annotation, return_types, expectation',
     [
         (
-            add,
+            NamedTuple('output', [('sum', int)]),
             [{'description': None, 'name': 'sum', 'type': 'Integer'},],
             does_not_raise()
         ),
         (
-            full_name,
+            NamedTuple('output', [('first', str), ('last', str)]),
             [{'description': None, 'name': 'first', 'type': 'String'},
              {'description': None, 'name': 'last', 'type': 'String'},],
             does_not_raise()
         ),
         (
-            optional_friend_count,
+            Optional[NamedTuple('output', [('count', int)])],
             None,
             pytest.raises(TypeError)
         ),
         (
-            age,
+            int,
             None,
             pytest.raises(TypeError)
         ),(
-           div,
+            None,
+            None,
+            pytest.raises(TypeError)
+        ),
+        (
+            'NO_ANNOTATION',
             None,
             does_not_raise()
         )
     ]
 )
-def test_get_function_return_types(func: Callable, return_types: List[dict], expectation):
+def test_get_function_return_types(return_annotation, return_types: List[dict], expectation):
     """Tests get_function_outputs, which returns a formatted list of
     return types.
 
     Args:
-        func (Callable): The python function to create a component from. The function
-            should either have a NamedTuple return type or no return type at all.
-        params (List[dict]): Params list with types converted to kubeflow spec.
+        annotation (Any): The return type to test.
+        return_types (List[dict]): The return type converted into the kubeflow output spec.
         expectation: Any corresponding expected errors for each
             set of parameters.
     """
+
+    def func():
+        ...
+
+    if return_annotation != 'NO_ANNOTATION':
+        func.__annotations__ = {'return' : return_annotation}
 
     with expectation:
         assert return_types == get_function_return_types(func=func)


### PR DESCRIPTION
Automatically define kubeflow component outputs from return type hint.


Waiting on confirmation to proceed with cleanup and testing:
https://github.com/GoogleCloudPlatform/automlops/issues/47



Example use case:
```
@AutoMLOps.component(
def run_simulation(...) -> NamedTuple("outputs", [("output_1", str), ("output_2", str)]):
   ...
   
@AutoMLOps.pipeline
def pipeline():   
    result = run_simulation(...)
    validate_simulation(
            output_1=result.outputs["output_1"],
            output_2=result.outputs["output_2"],
        )
```
Without this code change, result.outputs is not possible.